### PR TITLE
Disclaimer about data loss when uninstalling

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -144,8 +144,13 @@ Flags:
       --stos-cluster-namespace string    namespace of storageos cluster to be uninstalled
       --stos-operator-namespace string   namespace of storageos operator to be uninstalled (default "storageos")
 ```
-   
+
 Uninstall StorageOS from your Kubernetes cluster like so:
+
+> The following process **will not** remove data stored in disk by StorageOS.
+> If Etcd is removed, StorageOS Volumes won't be recoverable, but if the Etcd
+> cluster is kept intact, the volumes and their data will be available after a
+> reinstall.
 
 `kubectl storageos uninstall`
 


### PR DESCRIPTION
Disclaimer about data loss when uninstalling

    The kubectl storageos plugin deletes the k8s objects, CR, Operator, etc.
    But it doesn't erase the data in disk. The change attempts to make this
    clear.


I think the disclaimer is important for people to safely use the uninstall, @nolancon feel free to put that paragraph anywhere you deem proper if the place I put it doesn't work well. 